### PR TITLE
put a newline into 'start_test' output

### DIFF
--- a/src/robot/output/console/verbose.py
+++ b/src/robot/output/console/verbose.py
@@ -46,6 +46,7 @@ class VerboseOutput:
 
     def start_test(self, test):
         self._writer.info(test.name, test.doc)
+        self._writer._stdout.write('\n')
         self._running_test = True
 
     def end_test(self, test):


### PR DESCRIPTION
start test should only output the name and docs to the console. However, it does not put a newline at the end of the line, so the first use of `Log To Console` lands on that line as well.

Given these test cases:
![Screenshot 2022-12-06 083907](https://user-images.githubusercontent.com/119923080/205850857-21243d89-df19-449d-af30-4d20caa7f5be.png)

the output looks like this:
![Screenshot 2022-12-06 083840](https://user-images.githubusercontent.com/119923080/205850929-a45a3811-7606-44ff-a2a7-5d671374ec1e.png)

The proposed change makes it look like this:
![Screenshot 2022-12-06 083618](https://user-images.githubusercontent.com/119923080/205850998-e68c0f82-6aba-4091-a279-c6e4b8c962d5.png)

I believe this looks cleaner and is what a user would expect of logging.
The `--dotted` and `--quiet` options are unaffected. 